### PR TITLE
Add support for : as a statement delimiter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Major changes between releases
 
+## Changes in version X.Y.Z
+
+**STILL UNDER DEVELOPMENT; NOT RELEASED YET.
+
+*   Added support for `:` as a statement delimiter.
+
 ## Changes in version 0.1.0
 
 **Released on 2020-04-22.**

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -567,6 +567,19 @@ mod tests {
     }
 
     #[test]
+    fn test_statement_separators() {
+        do_ok_test(
+            "a=1\nb=2:c=3:' A comment: that follows\nd=4",
+            &[
+                Statement::Assignment(VarRef::new("a", VarType::Auto), Expr::Integer(1)),
+                Statement::Assignment(VarRef::new("b", VarType::Auto), Expr::Integer(2)),
+                Statement::Assignment(VarRef::new("c", VarType::Auto), Expr::Integer(3)),
+                Statement::Assignment(VarRef::new("d", VarType::Auto), Expr::Integer(4)),
+            ],
+        );
+    }
+
+    #[test]
     fn test_assignments() {
         do_ok_test(
             "a=1\nfoo$ = \"bar\"\nb$ = 3 + z",

--- a/tests/types.bas
+++ b/tests/types.bas
@@ -13,14 +13,11 @@
 ' License for the specific language governing permissions and limitations
 ' under the License.
 
-bool1 = TRUE
-bool2? = FALSE
+bool1 = TRUE: bool2? = FALSE
 PRINT bool1, bool2
 
-num1 = 1
-num2% = 2
+num1 = 1: num2% = 2
 PRINT num1, num2
 
-string1 = "foo"
-string2$ = "bar"
+string1 = "foo": string2$ = "bar"
 PRINT string1, string2


### PR DESCRIPTION
In BASIC programs, it's pretty common to combine multiple statements in
one line (e.g. positioning the cursor before calling PRINT), and the syntax
to do this is via a colon token.  Support this now.

I'm doing this by making the lexer not distinguish betweel EOL and colon
characters, which keeps the parser simple.  I'm not sure yet if this
decision will come to bite us later, but for now, and given that we do not
track line numbers, it is good enough.

Why the colon?  For historical reasons as far as I can tell: the semicolon
was already put to use to separte arguments in PRINT and INPUT calls, so
something else had to be used.