### PR TITLE
Make INPUT retry inputs on invalid answers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 
 *   Added the `MOD` operator to compute the remainder of an integer division.
 
+*   Made `INPUT` resilient to invalid boolean and integer answers by asking
+    the user to input them again.  The caller has no means of determining
+    failure so we must do this (like other BASIC implementations do).
+
 ## Changes in version 0.1.0
 
 **Released on 2020-04-22.**

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@
 )]
 #![warn(unsafe_code)]
 
-use endbasic;
 use failure::Fallible;
 use std::env;
 use std::fs::File;

--- a/tests/yes-no.in
+++ b/tests/yes-no.in
@@ -1,5 +1,6 @@
 true
 TRUE
+5
 yes
 YES
 y
@@ -9,6 +10,7 @@ false
 FALSE
 no
 NO
+foo
 n
 N
 y

--- a/tests/yes-no.out
+++ b/tests/yes-no.out
@@ -1,1 +1,3 @@
-Should we continue? Should we continue? Should we continue? Should we continue? Should we continue? Should we continue? Should we continue? Should we exit? Should we exit? Should we exit? Should we exit? Should we exit? Should we exit? Should we exit? 
+Should we continue? Should we continue? Should we continue? Retry input: Invalid boolean literal 5
+Should we continue? Should we continue? Should we continue? Should we continue? Should we continue? Should we exit? Should we exit? Should we exit? Should we exit? Should we exit? Retry input: Invalid boolean literal foo
+Should we exit? Should we exit? Should we exit? 


### PR DESCRIPTION
INPUT is a command and has no return value.  So, if the user supplies an
invalid input for non-string variables (those that require parsing), we
must ask for their input again.