### PR TITLE
Add the LOAD and SAVE commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ edition = "2018"
 travis-ci = { repository = "jmmv/endbasic", branch = "master" }
 
 [dependencies]
+dirs = "2.0"
 failure = "~0.1"
 getopts = "0.2"
 rustyline = "6.1.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,9 @@ not adhere to semantic versioning until 1.0.0.**
 
 *   Added an interactive command-line interface (aka a REPL) with builtin
     usage information via a new `HELP` command, the `CLEAR` command to
-    wipe machine state, and program editing via the `EDIT`, `LIST`, `NEW`,
-    `RENUM` and `RUN` commands.
+    wipe machine state, program editing via the `EDIT`, `LIST`, `NEW`,
+    `RENUM` and `RUN` commands, and program file manipulation via the
+    `LOAD` and `SAVE` commands.
 
 *   Added support for `:` as a statement delimiter.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ detailed usage information for any of them.
 The interactive interface has support for manipulating a stored program: that
 is, a program that lives in the memory of the interpreter.  To get started, use
 the `EDIT` command to enter new lines into the program, `LIST` to inspect its
-contents and `RUN` to execute it.
+contents and `RUN` to execute it.  You can save and restore programs from disk
+by using the `SAVE` and `LOAD` commands respectively, which by default are
+backed by an `endbasic` subdirectory under your `Documents` folder.
 
 The lines that `EDIT` prints during program editing are not meaningful to the
 program and only exist to support interactive editing.  Line numbers are

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -25,6 +25,7 @@ use rustyline::Editor;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{self, Write};
+use std::path::Path;
 use std::rc::Rc;
 
 /// The `CLEAR` command.
@@ -224,7 +225,10 @@ pub fn new_console() -> Rc<RefCell<dyn console::Console>> {
 }
 
 /// Enters the interactive interpreter.
-pub fn run_repl_loop() -> io::Result<()> {
+///
+/// `dir` specifies the directory that the interpreter will use for any commands that manipulate
+/// files.
+pub fn run_repl_loop(dir: &Path) -> io::Result<()> {
     let console = new_console();
     let mut machine = MachineBuilder::default()
         .add_builtin(Rc::from(ClearCommand {}))
@@ -232,7 +236,7 @@ pub fn run_repl_loop() -> io::Result<()> {
             output: Rc::from(RefCell::from(io::stdout())),
         }))
         .add_builtins(console::all_commands(console.clone()))
-        .add_builtins(program::all_commands(console))
+        .add_builtins(program::all_commands(console, dir))
         .build();
 
     println!();

--- a/tests/cli/help.out
+++ b/tests/cli/help.out
@@ -2,6 +2,8 @@ Usage: endbasic [options] [program-file]
 
 Options:
     -h, --help          show command-line usage information and exit
+        --programs-dir PATH
+                        directory where user programs are stored
         --version       show version information and exit
 
 Report bugs to: https://github.com/jmmv/endbasic/issues

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -26,7 +26,7 @@
 #![warn(unsafe_code)]
 
 use std::env;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -177,8 +177,6 @@ fn test_cli_help() {
 #[cfg(not(target_os = "linux"))]
 #[test]
 fn test_cli_program_name_uses_arg0() {
-    use std::fs;
-
     struct DeleteOnDrop<'a> {
         path: &'a Path,
     }
@@ -420,6 +418,26 @@ fn test_repl_interactive() {
         Behavior::File(src_path("tests/repl/interactive.out")),
         Behavior::Null,
     );
+}
+
+#[test]
+fn test_load_save() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::copy(
+        &src_path("tests/lang/hello.bas"),
+        &dir.path().join("hello.bas"),
+    )
+    .unwrap();
+    assert!(!dir.path().join("hello2.bas").exists());
+    check(
+        bin_path("endbasic"),
+        &["--programs-dir", dir.path().to_str().unwrap()],
+        0,
+        Behavior::File(src_path("tests/repl/load-save.in")),
+        Behavior::File(src_path("tests/repl/load-save.out")),
+        Behavior::Null,
+    );
+    assert!(dir.path().join("hello2.bas").exists());
 }
 
 #[test]

--- a/tests/repl/help.in
+++ b/tests/repl/help.in
@@ -38,6 +38,9 @@ HELP INPUT
 PRINT "Output from HELP LIST:"
 HELP LIST
 
+PRINT "Output from HELP LOAD:"
+HELP LOAD
+
 PRINT "Output from HELP NEW:"
 HELP NEW
 
@@ -49,3 +52,6 @@ HELP RENUM
 
 PRINT "Output from HELP RUN:"
 HELP RUN
+
+PRINT "Output from HELP SAVE:"
+HELP SAVE

--- a/tests/repl/help.out
+++ b/tests/repl/help.out
@@ -11,10 +11,12 @@ Output from HELP:
     HELP     Prints interactive help.
     INPUT    Obtains user input from the console.
     LIST     Lists the contents of the stored program.
+    LOAD     Loads the given program.
     NEW      Clears the stored program from memory.
     PRINT    Prints a message to the console.
     RENUM    Reassigns line numbers to make them all multiples of ten.
     RUN      Runs the stored program.
+    SAVE     Saves the current program in memory to the given filename.
 
     Type HELP followed by a command name for details on that command.
     Press CTRL+D to exit.
@@ -61,6 +63,14 @@ Output from HELP LIST:
 
     Lists the contents of the stored program.
 
+Output from HELP LOAD:
+
+    LOAD filename
+
+    Loads the given program.
+
+    The filename must be a string and must be a basename (no directory components).  The .BAS extension is optional, but if present, it must be .BAS.
+
 Output from HELP NEW:
 
     NEW
@@ -88,5 +98,13 @@ Output from HELP RUN:
     Runs the stored program.
 
     Note that the program runs in the context of the interpreter so it will pick up any variables and other state that may already be set.
+
+Output from HELP SAVE:
+
+    SAVE filename
+
+    Saves the current program in memory to the given filename.
+
+    The filename must be a string and must be a basename (no directory components).  The .BAS extension is optional, but if present, it must be .BAS.
 
 End of input by CTRL-D

--- a/tests/repl/load-save.in
+++ b/tests/repl/load-save.in
@@ -1,0 +1,28 @@
+' EndBASIC
+' Copyright 2020 Julio Merino
+'
+' Licensed under the Apache License, Version 2.0 (the "License"); you may not
+' use this file except in compliance with the License.  You may obtain a copy
+' of the License at:
+'
+'     http://www.apache.org/licenses/LICENSE-2.0
+'
+' Unless required by applicable law or agreed to in writing, software
+' distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+' WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+' License for the specific language governing permissions and limitations
+' under the License.
+
+' Interactive session that loads and saves programs.
+
+LOAD "hello.bas"
+PRINT "Running loaded hello.bas"
+RUN
+SAVE "hello2.bas"
+PRINT "Saved as hello2.bas"
+NEW
+PRINT "Running empty program after NEW"
+RUN
+LOAD "hello2.bas"
+PRINT "Running loaded hello2.bas"
+RUN

--- a/tests/repl/load-save.out
+++ b/tests/repl/load-save.out
@@ -1,0 +1,11 @@
+
+    Welcome to EndBASIC 0.1.0.
+    Type HELP for interactive usage information.
+
+Running loaded hello.bas
+Hello, world!
+Saved as hello2.bas
+Running empty program after NEW
+Running loaded hello2.bas
+Hello, world!
+End of input by CTRL-D


### PR DESCRIPTION
These commands store and restore the contents of the in-memory program
into/from disk.

To make things simple, these commands are backed by a single directory
that lives under ~/Documents/endbasic by default.  The directory can
be changed at startup time with the --programs-dir flag.