### PR TITLE
Disable Travis caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@
 
 language: rust
 
-cache:
-    - cargo: true
-    - npm: true
-
 os:
     - linux
     - osx


### PR DESCRIPTION
More than help, these were slowing down builds.  Disabling the caches
halves wall time in CI and total cumulative time spent by all jobs
from 61 min to 39 min.