### PR TITLE
Fix build after wasm-bindgen 0.2.66

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ os:
     - windows
 
 addons:
-    apt:
-        packages:
-        - firefox
+    chrome: stable
 
 env:
     - DO=lint

--- a/admin/travis-build.sh
+++ b/admin/travis-build.sh
@@ -77,7 +77,7 @@ do_test() {
 do_web() {
     cd web
     wasm-pack build
-    wasm-pack test --headless --firefox
+    wasm-pack test --headless --chrome
     cd -
 
     cd web/www

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -35,10 +35,6 @@ case "${DO}" in
         [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
         nvm install --lts
 
-        # The contents of ~/.cargo/ are cached across builds, and the wasm-pack
-        # installed asks for confirmation before overwriting files.  Avoid that
-        # by removing the offending files upfront.
-        rm -f ~/.cargo/bin/wasm-pack
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         ;;
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -46,3 +46,8 @@ vergen = "3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+[package.metadata.wasm-pack.profile.release]
+# Workaround for https://github.com/rustwasm/wasm-pack/issues/886, which
+# started happening with wasm-bindgen 0.2.66.
+wasm-opt = ["-O", "--enable-mutable-globals"]


### PR DESCRIPTION
Do this by allowing mutable globals, which is the current recommendation
per https://github.com/rustwasm/wasm-pack/issues/886.