### PR TITLE
Switch to futures-lite

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "jmmv/endbasic", branch = "master" }
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures-lite = "1.0"
 thiserror = "1.0"
 time = { version = "0.2", features = ["std"] }
 


### PR DESCRIPTION
We don't need any fancy functionality from the futures crate so switch to
futures-lite instead.  Cuts down build times on my Mac Pro 2013 by about
20 seconds.