### PR TITLE
Improve recursive async fns with futures-lite 1.1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "jmmv/endbasic", branch = "master" }
 
 [dependencies]
 async-trait = "0.1"
-futures-lite = "1.0"
+futures-lite = "1.1"
 thiserror = "1.0"
 time = { version = "0.2", features = ["std"] }
 


### PR DESCRIPTION
By upgrading to futures-lite 1.1, we can avoid the boxing of futures in
the return values of async fns and instead delegate the boxing to the
caller.  Results in nicer code.

Made possible by https://github.com/stjepang/futures-lite/issues/18.