### PR TITLE
Avoid using time::UtcOffset::local_offset_at

### DIFF
--- a/cli/src/store.rs
+++ b/cli/src/store.rs
@@ -59,8 +59,11 @@ impl Store for FileStore {
                     // expect symlinks in the programs directory anyway.  If we want to handle this
                     // better, we'll have to add a way to report file types.
                     let metadata = fs::metadata(de.path())?;
-                    let date = time::OffsetDateTime::from(metadata.modified()?)
-                        .to_offset(time::UtcOffset::current_local_offset());
+                    let offset = match time::UtcOffset::try_current_local_offset() {
+                        Ok(offset) => offset,
+                        Err(_) => time::UtcOffset::UTC,
+                    };
+                    let date = time::OffsetDateTime::from(metadata.modified()?).to_offset(offset);
                     let length = metadata.len();
 
                     entries.insert(


### PR DESCRIPTION
This function has been deprecated in time 0.2.23 because it silently
returned the UTC offset on failure instead of an error.  Do this same
thing on our own now, though this makes me wonder if we should be
doing something else instead.