### PR TITLE
Replace END WHILE with WEND

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,11 @@ not adhere to semantic versioning until 1.0.0.**
     having quick access to the program's contents is useful to showcase both
     code and output at once.
 
+*   Replaced `END WHILE` with `WEND` as the earlier BASICs did.  We could
+    probably support both, but for now, sticking to the simpler world of a
+    different keyword per statement seems nicer (and this matches what the
+    `FOR`/`NEXT` pair do).
+
 *   Fixed the expression parser to properly handle symbol names that appear
     immediately after a left parenthesis.  This broke with the addition of
     function calls.

--- a/cli/examples/guess.bas
+++ b/cli/examples/guess.bas
@@ -55,7 +55,7 @@ WHILE again?
             COLOR fg%, bg%
         END IF
         attempts% = attempts% - 1
-    END WHILE
+    WEND
 
     IF guess% = secret% THEN
         wins% = wins% + 1
@@ -70,7 +70,7 @@ WHILE again?
     PRINT
 
     INPUT "Do you want to play again"; again?
-END WHILE
+WEND
 
 COLOR
 CLS

--- a/cli/examples/tour.bas
+++ b/cli/examples/tour.bas
@@ -99,7 +99,7 @@ PRINT "While loops look like this:"
 PRINT
 PRINT "    WHILE a% < 10"
 PRINT "        a% = a% + 1"
-PRINT "    END WHILE"
+PRINT "    WEND"
 PRINT
 PRINT "For loops look like this:"
 PRINT

--- a/cli/tests/examples/tour.out
+++ b/cli/tests/examples/tour.out
@@ -67,7 +67,7 @@ While loops look like this:
 
     WHILE a% < 10
         a% = a% + 1
-    END WHILE
+    WEND
 
 For loops look like this:
 

--- a/cli/tests/lang/control-flow.bas
+++ b/cli/tests/lang/control-flow.bas
@@ -20,9 +20,9 @@ WHILE i < 5
     WHILE j < i
         PRINT i; j
         j = j + 1
-    END WHILE
+    WEND
     i = i + 1
-END WHILE
+WEND
 
 IF i = 5 THEN
     PRINT "Done!"

--- a/cli/tests/lang/yes-no.bas
+++ b/cli/tests/lang/yes-no.bas
@@ -16,9 +16,9 @@
 b? = TRUE
 WHILE b?
   INPUT "Should we continue"; b?
-END WHILE
+WEND
 
 b? = FALSE
 WHILE NOT b?
   INPUT "Should we exit"; b?
-END WHILE
+WEND

--- a/cli/tests/repl/colors.in
+++ b/cli/tests/repl/colors.in
@@ -16,7 +16,7 @@
 ' Tests that the background color is used to clear all new lines until the right
 ' margin of the screen.
 
-A = 5: WHILE A > 0: COLOR A, A - 1: PRINT "Hello": A = A - 1: END WHILE
+A = 5: WHILE A > 0: COLOR A, A - 1: PRINT "Hello": A = A - 1: WEND
 COLOR
 
 COLOR 4, 2

--- a/cli/tests/repl/console.bas
+++ b/cli/tests/repl/console.bas
@@ -36,8 +36,8 @@ WHILE row < 10
         PRINT "#"
         column = column + 1
         fg = (fg + 1) MOD 15
-    END WHILE
+    WEND
     row = row + 1
-END WHILE
+WEND
 
 LOCATE 100, 0

--- a/cli/tests/repl/dir.out
+++ b/cli/tests/repl/dir.out
@@ -6,39 +6,39 @@
 
 
     Modified              Size    Name
-    YYYY-MM-DD HH:MM      2107    DEMO:GUESS.BAS
+    YYYY-MM-DD HH:MM      2097    DEMO:GUESS.BAS
     YYYY-MM-DD HH:MM       651    DEMO:HELLO.BAS
-    YYYY-MM-DD HH:MM      6558    DEMO:TOUR.BAS
+    YYYY-MM-DD HH:MM      6553    DEMO:TOUR.BAS
 
-    3 file(s), 9316 bytes
+    3 file(s), 9301 bytes
 
 
     Modified              Size    Name
-    YYYY-MM-DD HH:MM      2107    DEMO:GUESS.BAS
+    YYYY-MM-DD HH:MM      2097    DEMO:GUESS.BAS
     YYYY-MM-DD HH:MM       651    DEMO:HELLO.BAS
-    YYYY-MM-DD HH:MM      6558    DEMO:TOUR.BAS
+    YYYY-MM-DD HH:MM      6553    DEMO:TOUR.BAS
     YYYY-MM-DD HH:MM         0    empty.bas
 
-    4 file(s), 9316 bytes
+    4 file(s), 9301 bytes
 
 [?1049h[?25l[38;5;15m[49m[2J[1;1H[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 1 [38;5;15m[49m[1;1H
 [1;1H[?25hf[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 2 [38;5;15m[49m[1;2H[?25hi[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 3 [38;5;15m[49m[1;3H[?25hr[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 4 [38;5;15m[49m[1;4H[?25hs[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 5 [38;5;15m[49m[1;5H[?25ht[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 1, Col 6 [38;5;15m[49m[1;6H[?25h[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 1 [38;5;15m[49m[2;1H[?25hs[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 2 [38;5;15m[49m[2;2H[?25he[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 3 [38;5;15m[49m[2;3H[?25hc[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 4 [38;5;15m[49m[2;4H[?25ho[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 5 [38;5;15m[49m[2;5H[?25hn[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 6 [38;5;15m[49m[2;6H[?25hd[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 2, Col 7 [38;5;15m[49m[2;7H[?25h[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 1 [38;5;15m[49m[3;1H[?25ht[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 2 [38;5;15m[49m[3;2H[?25hh[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 3 [38;5;15m[49m[3;3H[?25hi[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 4 [38;5;15m[49m[3;4H[?25hr[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 5 [38;5;15m[49m[3;5H[?25hd[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 3, Col 6 [38;5;15m[49m[3;6H[?25h[?25l[24;1H[38;5;15m[48;5;4m ESC Finish editing                                               | Ln 4, Col 1 [38;5;15m[49m[4;1H[?25h[?1049l
     Modified              Size    Name
-    YYYY-MM-DD HH:MM      2107    DEMO:GUESS.BAS
+    YYYY-MM-DD HH:MM      2097    DEMO:GUESS.BAS
     YYYY-MM-DD HH:MM       651    DEMO:HELLO.BAS
-    YYYY-MM-DD HH:MM      6558    DEMO:TOUR.BAS
+    YYYY-MM-DD HH:MM      6553    DEMO:TOUR.BAS
     YYYY-MM-DD HH:MM         0    empty.bas
     YYYY-MM-DD HH:MM        20    some lines and a long name.bas
 
-    5 file(s), 9336 bytes
+    5 file(s), 9321 bytes
 
 
     Modified              Size    Name
-    YYYY-MM-DD HH:MM      2107    DEMO:GUESS.BAS
+    YYYY-MM-DD HH:MM      2097    DEMO:GUESS.BAS
     YYYY-MM-DD HH:MM       651    DEMO:HELLO.BAS
-    YYYY-MM-DD HH:MM      6558    DEMO:TOUR.BAS
+    YYYY-MM-DD HH:MM      6553    DEMO:TOUR.BAS
     YYYY-MM-DD HH:MM        20    some lines and a long name.bas
 
-    4 file(s), 9336 bytes
+    4 file(s), 9321 bytes
 
 End of input by CTRL-D

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -75,7 +75,7 @@ Output from HELP LANG:
     Flow control:
         IF expr THEN: ...: ELSE IF expr THEN: ...: ELSE: ...: END IF
         FOR varref = expr TO expr [STEP int]: ...: NEXT
-        WHILE expr: ...: END WHILE
+        WHILE expr: ...: WEND
 
     Misc:
         st1: st2    Separates statements (same as a newline).

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -798,21 +798,21 @@ mod tests {
             WHILE n > 0
                 OUT "n is"; n
                 n = n - 1
-            END WHILE
+            WEND
         "#;
         do_ok_test(code, &["0"], &[]);
         do_ok_test(code, &["3"], &["n is 3", "n is 2", "n is 1"]);
 
-        do_ok_test("WHILE FALSE\nOUT 1\nEND WHILE", &[], &[]);
+        do_ok_test("WHILE FALSE\nOUT 1\nWEND", &[], &[]);
     }
 
     #[test]
     fn test_while_errors() {
-        do_simple_error_test("WHILE\nEND WHILE", "No expression in WHILE statement");
-        do_simple_error_test("WHILE\nEND IF", "WHILE without END WHILE");
+        do_simple_error_test("WHILE\nWEND", "No expression in WHILE statement");
+        do_simple_error_test("WHILE\nEND IF", "WHILE without WEND");
 
-        do_simple_error_test("WHILE 2\n", "WHILE without END WHILE");
-        do_simple_error_test("WHILE 2\nEND WHILE", "WHILE requires a boolean condition");
+        do_simple_error_test("WHILE 2\n", "WHILE without WEND");
+        do_simple_error_test("WHILE 2\nWEND", "WHILE requires a boolean condition");
     }
 
     #[test]

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -70,6 +70,7 @@ pub enum Token {
     Step,
     Then,
     To,
+    Wend,
     While,
 
     Dim,
@@ -289,6 +290,7 @@ impl<'a> Lexer<'a> {
             "THEN" => Ok(Token::Then),
             "TO" => Ok(Token::To),
             "TRUE" => Ok(Token::Boolean(true)),
+            "WEND" => Ok(Token::Wend),
             "WHILE" => Ok(Token::While),
             "XOR" => Ok(Token::Xor),
             _ => Ok(Token::Symbol(VarRef::new(s, vtype))),
@@ -633,9 +635,9 @@ mod tests {
 
     #[test]
     fn test_while() {
-        do_ok_test("WHILE END WHILE", &[Token::While, Token::End, Token::While]);
+        do_ok_test("WHILE WEND", &[Token::While, Token::Wend]);
 
-        do_ok_test("while end while", &[Token::While, Token::End, Token::While]);
+        do_ok_test("while wend", &[Token::While, Token::Wend]);
     }
 
     /// Syntactic sugar to instantiate a test that verifies the parsing of an operator.

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -50,7 +50,7 @@ const LANG_REFERENCE: &str = r"
     Flow control:
         IF expr THEN: ...: ELSE IF expr THEN: ...: ELSE: ...: END IF
         FOR varref = expr TO expr [STEP int]: ...: NEXT
-        WHILE expr: ...: END WHILE
+        WHILE expr: ...: WEND
 
     Misc:
         st1: st2    Separates statements (same as a newline).


### PR DESCRIPTION
This is a gratuitous change, yes, and is primarily driven by the fact that
END WHILE isn't being recognized by syntax highlighters in all cases.
Plus this better matches the retro feeling I'm trying to achieve in this
project.

The very early implementation of EndBASIC had WEND...  but I replaced it
with END WHILE to remain consistent with END IF.  I did not notice at the
time that FOR would require NEXT instead and that no BASIC I can see has
END FOR (not even Visual Basic, which has a very rich END statement).