### PR TITLE
Add input history tracking to the REPL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@ not adhere to semantic versioning until 1.0.0.**
     handling of the `:memory:` value.  Instead, this can now take arbitrary URIs
     to refer to drive targets.
 
+*   Added input history tracking to the REPL interface.
+
 ## Changes in version 0.6.0
 
 **Released on 2021-02-19.**

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -81,13 +81,14 @@ pub async fn run_repl_loop(
     console: Rc<RefCell<dyn Console>>,
 ) -> io::Result<i32> {
     let mut stop_reason = StopReason::Eof;
+    let mut history = vec![];
     while stop_reason == StopReason::Eof {
         let line = {
             let mut console = console.borrow_mut();
             if console.is_interactive() {
                 console.print("Ready")?;
             }
-            console::read_line(&mut *console, "", "").await
+            console::read_line(&mut *console, "", "", Some(&mut history)).await
         };
 
         match line {

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -205,7 +205,7 @@ pub struct RecordedProgram {
 #[async_trait(?Send)]
 impl Program for RecordedProgram {
     async fn edit(&mut self, console: &mut dyn Console) -> io::Result<()> {
-        let append = console::read_line(console, "", "").await?;
+        let append = console::read_line(console, "", "", None).await?;
         self.content.push_str(&append);
         self.content.push('\n');
         Ok(())


### PR DESCRIPTION
This is a long-time needed feature to make it less painful to interact
with the console, especially now that we have gained more complex file
system manipulation commands.